### PR TITLE
[Feature] Added geospatial functions

### DIFF
--- a/Source/URedis/Private/URedis.cpp
+++ b/Source/URedis/Private/URedis.cpp
@@ -77,10 +77,11 @@ uint64 FURedis::GeoAdd(FStringView key,
 }
 
 TOptional<double> FURedis::GeoDistance(FStringView key, FStringView member1,
-                                       FStringView member2) const {
-    auto result{_instance->geodist(TCHAR_TO_UTF8(key.GetData()),
-                                   TCHAR_TO_UTF8(member1.GetData()),
-                                   TCHAR_TO_UTF8(member2.GetData()))};
+                                       FStringView member2,
+                                       GeoUnit unit) const {
+    auto result{_instance->geodist(
+        TCHAR_TO_UTF8(key.GetData()), TCHAR_TO_UTF8(member1.GetData()),
+        TCHAR_TO_UTF8(member2.GetData()), (sw::redis::GeoUnit)unit)};
 
     if (!result) {
         return NullOpt;
@@ -100,6 +101,39 @@ TOptional<TPair<double, double>> FURedis::GeoPosition(
 
     return TOptional<TPair<double, double>>(
         TPair<double, double>(result.value().first, result.value().second));
+}
+
+TOptional<uint64> FURedis::GeoRadius(FStringView key,
+                                     TPair<double, double> location,
+                                     double radius, GeoUnit unit,
+                                     FStringView destination, bool store_dist,
+                                     uint64 count) const {
+    auto result{_instance->georadius(
+        TCHAR_TO_UTF8(key.GetData()),
+        std::pair<double, double>(location.Key, location.Value), radius,
+        (sw::redis::GeoUnit)unit, TCHAR_TO_UTF8(destination.GetData()),
+        store_dist, count)};
+
+    if (!result) {
+        return NullOpt;
+    }
+
+    return TOptional<uint64>(result.value());
+}
+
+TOptional<uint64> FURedis::GeoRadiusByMember(
+    FStringView key, FStringView member, double radius, GeoUnit unit,
+    FStringView destination, bool store_dist, uint64 count) const {
+    auto result{_instance->georadiusbymember(
+        TCHAR_TO_UTF8(key.GetData()), TCHAR_TO_UTF8(member.GetData()), radius,
+        (sw::redis::GeoUnit)unit, TCHAR_TO_UTF8(destination.GetData()),
+        store_dist, count)};
+
+    if (!result) {
+        return NullOpt;
+    }
+
+    return TOptional<uint64>(result.value());
 }
 
 #pragma endregion

--- a/Source/URedis/Private/URedis.cpp
+++ b/Source/URedis/Private/URedis.cpp
@@ -37,13 +37,13 @@ FString FURedis::Ping(TOptional<FString> message) const {
     return UTF8_TO_TCHAR(reply.c_str());
 }
 
-bool FURedis::Set(FStringView key, FStringView value) const {
+bool FURedis::Set(const FStringView key, const FStringView value) const {
     return _instance->set(TCHAR_TO_UTF8(key.GetData()),
                           TCHAR_TO_UTF8(value.GetData()));
 }
 
-TOptional<FString> FURedis::Get(FStringView key) const {
-    auto result{_instance->get(TCHAR_TO_UTF8(key.GetData()))};
+TOptional<FString> FURedis::Get(const FStringView key) const {
+    const auto result{_instance->get(TCHAR_TO_UTF8(key.GetData()))};
 
     if (!result) {
         return NullOpt;
@@ -52,18 +52,18 @@ TOptional<FString> FURedis::Get(FStringView key) const {
     return {UTF8_TO_TCHAR(result->c_str())};
 }
 
-uint64 FURedis::Del(FStringView key) const {
+uint64 FURedis::Del(const FStringView key) const {
     return _instance->del(TCHAR_TO_UTF8(key.GetData()));
 }
 
-void FURedis::Rename(FStringView key, FStringView newKey) const {
+void FURedis::Rename(const FStringView key, const FStringView newKey) const {
     _instance->rename(TCHAR_TO_UTF8(key.GetData()),
                       TCHAR_TO_UTF8(newKey.GetData()));
 }
 
 #pragma region Geostapial functions
 
-uint64 FURedis::GeoAdd(FStringView key,
+uint64 FURedis::GeoAdd(const FStringView key,
                        TTuple<FStringView, double, double> geoData) const {
     const auto &member = geoData.Get<0>();
     const auto longitude = geoData.Get<1>();
@@ -76,64 +76,66 @@ uint64 FURedis::GeoAdd(FStringView key,
     return _instance->geoadd(TCHAR_TO_UTF8(key.GetData()), convertedGeoData);
 }
 
-TOptional<double> FURedis::GeoDistance(FStringView key, FStringView member1,
-                                       FStringView member2,
-                                       GeoUnit unit) const {
-    auto result{_instance->geodist(
+TOptional<double> FURedis::GeoDistance(const FStringView key,
+                                       const FStringView member1,
+                                       const FStringView member2,
+                                       const GeoUnit unit) const {
+    const auto result{_instance->geodist(
         TCHAR_TO_UTF8(key.GetData()), TCHAR_TO_UTF8(member1.GetData()),
-        TCHAR_TO_UTF8(member2.GetData()), (sw::redis::GeoUnit)unit)};
+        TCHAR_TO_UTF8(member2.GetData()),
+        static_cast<sw::redis::GeoUnit>(unit))};
 
     if (!result) {
         return NullOpt;
     }
 
-    return {result.value()};
+    return *result;
 }
 
 TOptional<TPair<double, double>> FURedis::GeoPosition(
-    FStringView key, FStringView member) const {
-    auto result{_instance->geopos(TCHAR_TO_UTF8(key.GetData()),
-                                  TCHAR_TO_UTF8(member.GetData()))};
+    const FStringView key, const FStringView member) const {
+    const auto result{_instance->geopos(TCHAR_TO_UTF8(key.GetData()),
+                                        TCHAR_TO_UTF8(member.GetData()))};
 
     if (!result) {
         return NullOpt;
     }
 
-    return TOptional<TPair<double, double>>(
-        TPair<double, double>(result.value().first, result.value().second));
+    return TPair<double, double>(result->first, result->second);
 }
 
-TOptional<uint64> FURedis::GeoRadius(FStringView key,
-                                     TPair<double, double> location,
-                                     double radius, GeoUnit unit,
-                                     FStringView destination, bool store_dist,
-                                     uint64 count) const {
-    auto result{_instance->georadius(
-        TCHAR_TO_UTF8(key.GetData()),
-        std::pair<double, double>(location.Key, location.Value), radius,
-        (sw::redis::GeoUnit)unit, TCHAR_TO_UTF8(destination.GetData()),
-        store_dist, count)};
+TOptional<uint64> FURedis::GeoRadius(const FStringView key,
+                                     const TPair<double, double> location,
+                                     const double radius, const GeoUnit unit,
+                                     const FStringView destination,
+                                     const bool storeDist,
+                                     const uint64 count) const {
+    const auto result{_instance->georadius(
+        TCHAR_TO_UTF8(key.GetData()), std::pair(location.Key, location.Value),
+        radius, static_cast<sw::redis::GeoUnit>(unit),
+        TCHAR_TO_UTF8(destination.GetData()), storeDist, count)};
 
     if (!result) {
         return NullOpt;
     }
 
-    return TOptional<uint64>(result.value());
+    return *result;
 }
 
 TOptional<uint64> FURedis::GeoRadiusByMember(
-    FStringView key, FStringView member, double radius, GeoUnit unit,
-    FStringView destination, bool store_dist, uint64 count) const {
-    auto result{_instance->georadiusbymember(
+    const FStringView key, const FStringView member, const double radius,
+    const GeoUnit unit, const FStringView destination, const bool storeDist,
+    const uint64 count) const {
+    const auto result{_instance->georadiusbymember(
         TCHAR_TO_UTF8(key.GetData()), TCHAR_TO_UTF8(member.GetData()), radius,
-        (sw::redis::GeoUnit)unit, TCHAR_TO_UTF8(destination.GetData()),
-        store_dist, count)};
+        static_cast<sw::redis::GeoUnit>(unit),
+        TCHAR_TO_UTF8(destination.GetData()), storeDist, count)};
 
     if (!result) {
         return NullOpt;
     }
 
-    return TOptional<uint64>(result.value());
+    return *result;
 }
 
 #pragma endregion

--- a/Source/URedis/Public/URedis.h
+++ b/Source/URedis/Public/URedis.h
@@ -170,7 +170,7 @@ public:
      * @param destination The key where the results will be stored. This
      * parameter is a constant reference to an FStringView object representing
      * the destination key.
-     * @param store_dist A boolean flag indicating whether to store the
+     * @param storeDist A boolean flag indicating whether to store the
      * distances from the central point to each member.
      * @param count The maximum number of members to return.
      * @return An optional containing the number of members found within the
@@ -178,7 +178,7 @@ public:
      */
     TOptional<uint64> GeoRadius(FStringView key, TPair<double, double> location,
                                 double radius, GeoUnit unit,
-                                FStringView destination, bool store_dist,
+                                FStringView destination, bool storeDist,
                                 uint64 count) const;
 
     /**
@@ -202,7 +202,7 @@ public:
      * @param destination The key where the results will be stored. This
      * parameter is a constant reference to an FStringView object representing
      * the destination key.
-     * @param store_dist A boolean flag indicating whether to store the
+     * @param storeDist A boolean flag indicating whether to store the
      * distances from the specified member to each found member.
      * @param count The maximum number of members to return.
      * @return An optional containing the number of members found within the
@@ -210,8 +210,8 @@ public:
      */
     TOptional<uint64> GeoRadiusByMember(FStringView key, FStringView member,
                                         double radius, GeoUnit unit,
-                                        FStringView destination,
-                                        bool store_dist, uint64 count) const;
+                                        FStringView destination, bool storeDist,
+                                        uint64 count) const;
 
 #pragma endregion
 

--- a/Source/URedis/Public/URedis.h
+++ b/Source/URedis/Public/URedis.h
@@ -73,6 +73,27 @@ public:
      */
     void Rename(FStringView key, FStringView newKey) const;
 
+#pragma region Geospatial functions
+
+    uint64 GeoAdd(FStringView key,
+                  TTuple<FStringView, double, double> geoData) const;
+
+    TOptional<double> GeoDistance(FStringView key, FStringView member1,
+                                  FStringView member2) const;
+
+    TOptional<TPair<double, double>> GeoPosition(FStringView key,
+                                                 FStringView member) const;
+
+    TOptional<uint64> GeoRadius(FStringView key, TPair<double, double> location,
+                                double radius, FStringView destination,
+                                bool store_dist, uint64 count) const;
+
+    TOptional<uint64> GeoRadiusByMember(FStringView key, FStringView member,
+                                double radius, FStringView destination,
+                                bool store_dist, uint64 count) const;
+
+#pragma endregion
+
 private:
     TUniquePtr<sw::redis::Redis> _instance{};
 };

--- a/Source/URedis/Public/URedis.h
+++ b/Source/URedis/Public/URedis.h
@@ -89,8 +89,8 @@ public:
                                 bool store_dist, uint64 count) const;
 
     TOptional<uint64> GeoRadiusByMember(FStringView key, FStringView member,
-                                double radius, FStringView destination,
-                                bool store_dist, uint64 count) const;
+                                        double radius, FStringView destination,
+                                        bool store_dist, uint64 count) const;
 
 #pragma endregion
 

--- a/Source/URedis/Public/URedis.h
+++ b/Source/URedis/Public/URedis.h
@@ -75,21 +75,142 @@ public:
 
 #pragma region Geospatial functions
 
+    /**
+     * @brief Enum class representing units of geographical distance.
+     *
+     * This enum class defines the various units of measurement that can be used
+     * to specify distances in geographical contexts. It includes meters (M),
+     * kilometers (KM), miles (MI), and feet (FT).
+     */
+    enum class GeoUnit { M, KM, MI, FT };
+
+    /**
+     * @brief Adds a geographical location to a specified key.
+     *
+     * This function adds a geographical location specified by its name and
+     * coordinates (longitude and latitude) to a key.
+     * The location is defined using a tuple containing the
+     * name of the location, the longitude, and the latitude.
+     *
+     * @param key The key to which the geographical location will be added. This
+     * parameter is a constant reference to an FStringView object representing
+     * the key.
+     * @param geoData A tuple containing the geographical data:
+     *                - The name of the location (FStringView).
+     *                - The longitude of the location (double).
+     *                - The latitude of the location (double).
+     * @return The number of elements that were added to the sorted set, not
+     * including all the elements already existing for which the score was
+     * updated.
+     */
     uint64 GeoAdd(FStringView key,
                   TTuple<FStringView, double, double> geoData) const;
 
+    /**
+     * @brief Calculates the distance between two geographical members.
+     *
+     * This function computes the distance between two members stored in a
+     * specified key, returning the distance in the specified unit of
+     * measurement. The members and the unit are specified as parameters.
+     *
+     * @param key The key containing the geographical members. This parameter is
+     * a constant reference to an FStringView object representing the key.
+     * @param member1 The first member whose geographical position will be used
+     * in the distance calculation. This parameter is a constant
+     * reference to an FStringView object representing the first member.
+     * @param member2 The second member whose geographical position will be used
+     in the distance calculation. This parameter is a constant
+     * reference to an FStringView object representing the second member.
+     * @param unit The unit of measurement for the distance. This parameter is
+     * of type GeoUnit and can be meters (M), kilometers (KM), miles
+     * (MI), or feet (FT).
+     * @return An optional containing the distance between the two members if
+     * both members exist; otherwise, an empty optional.
+     */
     TOptional<double> GeoDistance(FStringView key, FStringView member1,
-                                  FStringView member2) const;
+                                  FStringView member2, GeoUnit unit) const;
 
+    /**
+     * @brief Retrieves the geographical position of a member.
+     *
+     * This function returns the longitude and latitude of a specified member
+     * stored in a given key. If the member exists, the function returns a pair
+     * containing the longitude and latitude. If the member does not exist, it
+     * returns an empty optional.
+     *
+     * @param key The key containing the geographical member. This parameter is
+     * a constant reference to an FStringView object representing the key.
+     * @param member The member whose geographical position is to be retrieved.
+     * This parameter is a constant reference to an FStringView
+     * object representing the member.
+     * @return An optional containing a pair of doubles representing the
+     * longitude and latitude of the member if the member exists;
+     * otherwise, an empty optional.
+     */
     TOptional<TPair<double, double>> GeoPosition(FStringView key,
                                                  FStringView member) const;
 
+    /**
+     * @brief Finds members within a radius from a specified geographical point.
+     *
+     * This function returns the number of members within a specified radius
+     * from a given geographical location (longitude and latitude) stored in a
+     * key. The results can be stored in a destination key, and optionally the
+     * distances from the central point to each member can also be stored.
+     *
+     * @param key The key containing the geographical members. This parameter is
+     * a constant reference to an FStringView object representing the key.
+     * @param location A pair of doubles representing the longitude and latitude
+     * of the central point.
+     * @param radius The radius around the central point within which to find
+     * members.
+     * @param unit The unit of measurement for the radius. This parameter is of
+     * type GeoUnit and can be meters (M), kilometers (KM), miles (MI), or feet
+     * (FT).
+     * @param destination The key where the results will be stored. This
+     * parameter is a constant reference to an FStringView object representing
+     * the destination key.
+     * @param store_dist A boolean flag indicating whether to store the
+     * distances from the central point to each member.
+     * @param count The maximum number of members to return.
+     * @return An optional containing the number of members found within the
+     * radius if the operation is successful; otherwise, an empty optional.
+     */
     TOptional<uint64> GeoRadius(FStringView key, TPair<double, double> location,
-                                double radius, FStringView destination,
-                                bool store_dist, uint64 count) const;
+                                double radius, GeoUnit unit,
+                                FStringView destination, bool store_dist,
+                                uint64 count) const;
 
+    /**
+     * @brief Finds members within a radius from a specified member.
+     *
+     * This function returns the number of members within a specified radius
+     * from a given member stored in a key. The results can be stored in a
+     * destination key, and optionally the distances from the specified member
+     * to each found member can also be stored.
+     *
+     * @param key The key containing the geographical members. This parameter is
+     * a constant reference to an FStringView object representing the key.
+     * @param member The member from which the radius is calculated. This
+     * parameter is a constant reference to an FStringView object representing
+     * the member.
+     * @param radius The radius around the specified member within which to find
+     * other members.
+     * @param unit The unit of measurement for the radius. This parameter is of
+     * type GeoUnit and can be meters (M), kilometers (KM), miles (MI), or feet
+     * (FT).
+     * @param destination The key where the results will be stored. This
+     * parameter is a constant reference to an FStringView object representing
+     * the destination key.
+     * @param store_dist A boolean flag indicating whether to store the
+     * distances from the specified member to each found member.
+     * @param count The maximum number of members to return.
+     * @return An optional containing the number of members found within the
+     * radius if the operation is successful; otherwise, an empty optional.
+     */
     TOptional<uint64> GeoRadiusByMember(FStringView key, FStringView member,
-                                        double radius, FStringView destination,
+                                        double radius, GeoUnit unit,
+                                        FStringView destination,
                                         bool store_dist, uint64 count) const;
 
 #pragma endregion


### PR DESCRIPTION
Added public C++ functions due to issue #11 :
--
* GeoAdd - Adds the specified geospatial items (longitude, latitude, name) to the specified key.
* GeoDistance - Return the distance between two members in the geospatial index represented by the sorted set.
* GeoRadius- Return the members of a sorted set populated with geospatial information, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
* GeoPosition - Return the positions (longitude, latitude) of all the specified members of the geospatial index represented by the sorted set at key.
* GeoRadiusByMember - This command is exactly like GEORADIUS with the sole difference that instead of taking, as the center of the area to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial index represented by the sorted set.